### PR TITLE
Module moved to new maintainer's github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+MOVED TO https://github.com/surrealzerg/foundry-die-hard-v13
+
+
 2026-03-07 - UI Fixes
 2026-03-06 - Fixed Monk's Token Bar compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/UranusBytes/foundry-die-hard) ![GitHub Releases](https://img.shields.io/github/downloads/UranusBytes/foundry-die-hard/latest/total) ![GitHub Releases](https://img.shields.io/github/downloads/UranusBytes/foundry-die-hard/total)
+2026-03-07 - UI Fixes
+2026-03-06 - Fixed Monk's Token Bar compatibility
 
-![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Ffoundry-die-hard&colorB=4aa94a) ![Foundry Version](https://img.shields.io/endpoint?url=https://foundryshields.com/version?url=https%3A%2F%2Fgithub.com%2FUranusBytes%2Ffoundry-die-hard%2Freleases%2Flatest%2Fdownload%2Fmodule.json) 
+Updated to Work for V13.
+
+Original development by https://github.com/UranusBytes/foundry-die-hard
 
 Die Hard
 ========
+
 This Foundry VTT module is intended to provide functionality that modifies/adjusted die rolls in certain systems.
 
 **NOTE:** This module is still BETA and under active development.  Functionality is still prone to change and/or bugs to be discovered.

--- a/module.json
+++ b/module.json
@@ -2,8 +2,8 @@
     "id": "foundry-die-hard",
     "title": "Die Hard",
     "description": "Adjustments for DND5e & PF2e die rolls like fudging...",
-    "author": "Jeremy (UranusBytes)",
-    "version": "0.1.1",
+    "author": "Surreal and Jeremy (UranusBytes)",
+    "version": "0.2.3",
     "esmodules": [
         "scripts/die-hard.js"
     ],
@@ -29,12 +29,11 @@
         }
     },
     "compatibility": {
-		"minimum": 10,
-		"verified": "10.291"
+		"minimum": 13,
+		"verified": "13.351"
 	},
-    "url": "https://github.com/UranusBytes/foundry-die-hard",
-    "manifest": "https://github.com/UranusBytes/foundry-die-hard/releases/latest/download/module.json",
-    "readme": "https://github.com/UranusBytes/foundry-die-hard/blob/main/README.md",
-    "changelog": "https://github.com/UranusBytes/foundry-die-hard/blob/main/CHANGELOG.md",
-    "download": "https://github.com/UranusBytes/foundry-die-hard/releases/download/0.1.1/module.zip"
+    "url": "https://github.com/surrealzerg/foundry-die-hard-v13",
+    "manifest": "https://github.com/surrealzerg/foundry-die-hard-v13/raw/refs/heads/main/module.json",
+    "readme": "https://github.com/surrealzerg/foundry-die-hard-v13/raw/refs/heads/main/README.md",
+    "download": "https://github.com/surrealzerg/foundry-die-hard-v13/raw/refs/heads/main/foundry-die-hard.zip"
 }


### PR DESCRIPTION
SurrealZerg has updated the module for v13 compatibility. Module.json will now download the module from new maintainer's repo (https://github.com/surrealzerg/foundry-die-hard-v13).